### PR TITLE
Fix ID trait not showing for some components

### DIFF
--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -403,12 +403,13 @@ export async function initEditor(config: EditorConfig) {
         },
       },
     }
-    editor.DomComponents.addType('image', typeConfig)
-    editor.DomComponents.addType('iframe', typeConfig)
+    const dc = editor.DomComponents;
+    dc.addType('image', typeConfig)
+    dc.addType('iframe', typeConfig)
 
-    
-    editor.DomComponents.getTypes().map(type => {
-    editor.DomComponents.addType(type.id, {
+    dc.getTypes().map(type => {
+      const dcmp = dc.getType(type.id)?.model.prototype;
+      dc.addType(type.id, {
       model: {
         defaults: {
           traits: [
@@ -417,10 +418,16 @@ export async function initEditor(config: EditorConfig) {
               label: 'ID',
               name: 'id',
             },
-            ...(editor.DomComponents.getType(type.id)?.model.prototype.defaults.traits || []),
+            ...(dcmp.defaults.traits || []),
           ]
-        }
-      }
+        },
+        init(...args) {
+            (dcmp.init.apply(this, args));
+            if (!this.getAttributes().id) {
+              this.addAttributes({ id: this.getId() });
+            }
+          }
+      },
     })
   })
 

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -406,6 +406,7 @@ export async function initEditor(config: EditorConfig) {
     editor.DomComponents.addType('image', typeConfig)
     editor.DomComponents.addType('iframe', typeConfig)
 
+    
     editor.DomComponents.getTypes().map(type => {
     editor.DomComponents.addType(type.id, {
       model: {

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -406,6 +406,25 @@ export async function initEditor(config: EditorConfig) {
     editor.DomComponents.addType('image', typeConfig)
     editor.DomComponents.addType('iframe', typeConfig)
 
+    editor.DomComponents.getTypes().map(type => {
+    editor.DomComponents.addType(type.id, {
+      model: {
+        defaults: {
+          traits: [
+            {
+              type: 'text',
+              label: 'ID',
+              name: 'id',
+            },
+            ...(editor.DomComponents.getType(type.id)?.model.prototype.defaults.traits || []),
+          ]
+        }
+      }
+    })
+  })
+
+  
+
     // Adjustments to do when the editor is ready
     editor.on('load', () => {
       const views = editor.Panels.getPanel('views')


### PR DESCRIPTION
Resolves [#1640](https://github.com/silexlabs/Silex/issues/1640)

Using the refrenced [example of "trait" added to all components](https://github.com/silexlabs/silex-lib/blob/25dc652527a7fb9c888066e9b5a09b84f7dc49e6/src/ts/client/grapesjs/cms/traits.ts) I was able to add the id trait to all components except the video component although the video type was inside editor.DomComponents.getTypes() but the ID trait was not added to it.

### Outcome:
All Blocks should now have an ID trait with the ID text field value set to the generated ID.

### Things to Note:
The page body now has an ID trait.
The video block is the only block that is not affected.