### PR TITLE
Quick styling background 1653

### DIFF
--- a/src/css/panels.scss
+++ b/src/css/panels.scss
@@ -259,3 +259,19 @@
     }
   }
 }
+.silex-quick-styling {
+  padding: 8px;
+  border-bottom: 1px solid var(--silex-border-color-strong);
+}
+
+.silex-quick-styling__title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.silex-quick-styling__btn {
+  width: 100%;
+  padding: 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -478,11 +478,6 @@ export async function initEditor(config: EditorConfig) {
           const sm = editor.StyleManager
           const sector = sm.getSector('decorations')
 
-          if (!sector) {
-            console.warn('[Quick Styling] Decorations sector not found')
-            return
-          }
-
           sector.set('open', true)
 
           setTimeout(() => {

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -450,6 +450,68 @@ export async function initEditor(config: EditorConfig) {
     try {
       /* @ts-ignore */
       editor = grapesjs.init(config)
+      editor.on('load', () => {
+        const sectorsEl = document.querySelector('.gjs-sm-sectors')
+        if (!sectorsEl) return
+
+        
+        if (document.getElementById('silex-quick-styling')) return
+
+        const quick = document.createElement('div')
+        quick.id = 'silex-quick-styling'
+        quick.className = 'silex-quick-styling'
+
+        quick.innerHTML = `
+    <div class="silex-quick-styling__title">Quick Styling</div>
+    <button type="button"
+            class="silex-quick-styling__btn"
+            aria-label="Jump to Background styling">
+      Jump to Background
+    </button>
+  `
+
+        
+        sectorsEl.parentElement?.insertBefore(quick, sectorsEl)
+
+        const btn = quick.querySelector('button')
+        btn?.addEventListener('click', () => {
+          const sm = editor.StyleManager
+          const sector = sm.getSector('decorations')
+
+          if (!sector) {
+            console.warn('[Quick Styling] Decorations sector not found')
+            return
+          }
+
+          sector.set('open', true)
+
+          setTimeout(() => {
+            const root = document.querySelector('.gjs-sm-sectors')
+            if (!root) return
+
+            const properties = Array.from(
+              root.querySelectorAll('.gjs-sm-property')
+            ) as HTMLElement[]
+
+            const backgroundProp = properties.find(prop => {
+              const label = prop.querySelector('.gjs-sm-label')
+              return (label?.textContent || '')
+                .trim()
+                .toLowerCase()
+                .startsWith('background')
+            })
+
+            if (backgroundProp) {
+              backgroundProp.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+              })
+            } else {
+              console.warn('[Quick Styling] Background property not found')
+            }
+          }, 0)
+        })
+      })
     } catch(e) {
       console.error('Error initializing GrapesJs with plugins:', plugins, e)
       reject(e)

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -501,9 +501,7 @@ export async function initEditor(config: EditorConfig) {
                 behavior: 'smooth',
                 block: 'center',
               })
-            } else {
-              console.warn('[Quick Styling] Background property not found')
-            }
+            } 
           }, 0)
         })
       })


### PR DESCRIPTION
Improve Background Discoverability with Quick Styling Button

This PR introduces a small UX improvement to help beginners more easily locate Background styling controls.

What’s added
A Quick Styling section above the Style Manager sectors
A "Jump to Background" button
When clicked:
Opens the Decorations sector using the GrapesJS StyleManager API
Smoothly scrolls to the Background property controls

Why
During usability testing, beginner users had difficulty locating background styling options inside the Style Manager. This change improves discoverability without modifying core behavior.

Implementation Notes
Uses editor.StyleManager.getSector('decorations')
Avoids fragile DOM-only class manipulation
Keeps changes minimal and isolated