### PR TITLE
feat(style-manager): add Basics sector to improve beginner discoverability

### DIFF
--- a/src/ts/client/grapesjs/basics.ts
+++ b/src/ts/client/grapesjs/basics.ts
@@ -1,0 +1,54 @@
+import { Editor } from 'grapesjs'
+
+/**
+ * Adds a beginner-friendly "Basics" sector to the Style Manager.
+ * Surfaces common properties while keeping the existing sectors intact.
+ */
+export default (editor: Editor) => {
+  editor.on('load', () => {
+    const sm = editor.StyleManager
+
+    // Avoid adding twice
+    if (sm.getSector('basics')) return
+
+    sm.addSector(
+      'basics',
+      {
+        name: 'Basics',
+        open: true,
+        properties: [
+          {
+            label: 'Background color',
+            property: 'background-color',
+            type: 'color',
+            default: '',
+          },
+          {
+            label: 'Text color',
+            property: 'color',
+            type: 'color',
+            default: '',
+          },
+          {
+            label: 'Font size',
+            property: 'font-size',
+            type: 'number',
+            units: ['px', 'em', 'rem', '%'],
+            default: '',
+          },
+          {
+            label: 'Padding',
+            type: 'composite',
+            properties: [
+              { property: 'padding-top' },
+              { property: 'padding-right' },
+              { property: 'padding-bottom' },
+              { property: 'padding-left' },
+            ],
+          },
+        ],
+      },
+      { at: 0 } // top of the panel
+    )
+  })
+}

--- a/src/ts/client/grapesjs/index.ts
+++ b/src/ts/client/grapesjs/index.ts
@@ -45,6 +45,8 @@ import breadcrumbsPlugin from './breadcrumbs'
 import imgPlugin from './img'
 import liPlugin from './li'
 import flexPlugin from './flex'
+import basics from './basics'
+import basicsPlugin from './basics'
 import cssPropsPlugin from './css-props'
 import rateLimitPlugin from '@silexlabs/grapesjs-storage-rate-limit'
 import borderPugin from 'grapesjs-style-border'
@@ -101,6 +103,7 @@ const plugins = [
   {name: './LoginDialog', value: loginDialogPlugin},
   {name: '@silexlabs/grapesjs-loading', value: loadingPlugin},
   {name: './breadcrumbs', value: breadcrumbsPlugin},
+  {name: './basics', value: basicsPlugin},
   {name: './img', value: imgPlugin},
   {name: './li', value: liPlugin},
   {name: './flex', value: flexPlugin},


### PR DESCRIPTION
Closes #1653

Following the discussion and feedback from @lexoyo, this PR replaces the previous “Jump to Background” approach with a proper GrapesJS plugin implementation

What this PR does 

- adds a new "Basics" sector at the top of the Style Manager
- Surfaces the most common beginner properties 
       - Background color
       - Text color
       - Font size
       - Padding   - 
- Uses StyleManager.addSector() (no direct DOM manipulation)
- keeps properties available in their original sectors as well  

Why
during usability testing, beginners struggled to find basic styling options because:
Sector name like "Decorations" are not intuitive
Common properties are spread across multiple sections 
Background styling was especially hard to locate 

this approach:
improves first-time user discoverability 
matches patterns used in builders like Webflow and Elementor
preserves the full advanced structure for experienced users 

implementation notes
implemented as a standalone GrapesJS plugin
Uses existing StyleManager APIs
Follows existing plugin patterns (img.ts, flex.ts, etc.)

would love feedback on whether this matches the intended direction discussed in the issue 