### PR TITLE
fix: resolve publication manager issue "missing index.html" (#1689)

### DIFF
--- a/src/ts/client/grapesjs/PublicationManager.ts
+++ b/src/ts/client/grapesjs/PublicationManager.ts
@@ -305,6 +305,22 @@ export class PublicationManager {
       // Get the data to publish, clone the objects because plugins can change it
       const projectData = { ...this.editor.getProjectData() as WebsiteData }
       const siteSettings = { ...this.editor.getModel().get('settings') as WebsiteSettings }
+      const pages = (projectData.pages as any[]) || []
+      const hasIndex = pages.some(page => {
+      const name = page?.name || ''
+      return name.toLowerCase() === 'index'
+       })
+       console.log(hasIndex);
+      if (!hasIndex) {
+        this.editor.runCommand('notifications:add', {
+          id: 'publish-missing-index-warning',
+          type: 'warning',
+          group: 'publication',
+          message:
+            'No page named "index" found. The first page will be used as homepage. Rename a page to "index" to control homepage.',
+        })
+      }      
+      
       // Check for missing SEO tags and warn user
       this.checkSeoTags(siteSettings)
       let preventDefaultStart = false
@@ -526,6 +542,8 @@ export class PublicationManager {
   }
 
   async *getHtmlFilesYield(siteSettings: WebsiteSettings, preventDefault): AsyncGenerator<WebsiteFile | undefined> {
+    const pages = this.editor.Pages.getAll()
+    const hasIndex = pages.some(p => getPageSlug(p.get('name')) === 'index')
     for (const page of this.editor.Pages.getAll()) {
       // Clone the settings because plugins can change them
       const clonedSiteSettings = { ...siteSettings }
@@ -544,7 +562,13 @@ export class PublicationManager {
       yield undefined // Yield control to avoid blocking the main thread
 
       // Transform the file paths
-      const slug = getPageSlug(page.get('name'))
+      let slug = getPageSlug(page.get('name'));
+      // if no index page exist make the first page as home page
+      const firstPageId = pages[0]?.getId()
+
+      if (!hasIndex && page.getId() === firstPageId) {
+        slug = 'index'
+      }
       const cssInitialPath = `/css/${slug}-${await hashString(cssContent)}.css`
       const htmlInitialPath = `/${slug}.html`
       const cssPermalink = transformPermalink(this.editor, cssInitialPath, ClientSideFileType.CSS, Initiator.HTML)

--- a/src/ts/client/grapesjs/PublicationManager.ts
+++ b/src/ts/client/grapesjs/PublicationManager.ts
@@ -576,24 +576,34 @@ export class PublicationManager {
       const cssContent = this.editor.getCss({ component: body })
       console.time(`getHtml ${page.getId()} ${page.get('name')}`)
       const htmlContent = this.editor.getHtml({ component: body })
+      console.log(htmlContent)
       console.timeEnd(`getHtml ${page.getId()} ${page.get('name')}`)
       yield undefined // Yield control to avoid blocking the main thread
 
       // Transform the file paths
-      const originalSlug = getPageSlug(page.get('name'))
+      const rawSlug = getPageSlug(page.get('name'))
+      const originalSlug = rawSlug.replace(/^Slug/i, '')
       let slug = originalSlug
       // if no index page exist make the first page as home page
       const promotedToIndex = shouldPromoteFirstPage && page.getId() === firstPageId
+      console.log({
+  promotedToIndex,
+  pageId: page.getId(),
+  firstPageId,
+  originalSlug
+})
       if (promotedToIndex) {
         slug = 'index'
       }
+      console.log(htmlContent)
       let finalHtml = htmlContent
       if (promotedToIndex) {
-        finalHtml = finalHtml.replaceAll(
-          `href="./${originalSlug}.html"`,
-          'href="./"'
+        finalHtml = finalHtml.replace(
+          new RegExp(`\\.\\/(${originalSlug})\\.html`, 'gi'),
+          './'
         )
       }
+      console.log(finalHtml)
       const cssInitialPath = `/css/${slug}-${await hashString(cssContent)}.css`
       const htmlInitialPath = `/${slug}.html`
       const cssPermalink = transformPermalink(this.editor, cssInitialPath, ClientSideFileType.CSS, Initiator.HTML)

--- a/src/ts/client/grapesjs/PublicationManager.ts
+++ b/src/ts/client/grapesjs/PublicationManager.ts
@@ -17,7 +17,7 @@
 
 import { getPageSlug } from '../../page'
 import { ApiConnectorLoggedInPostMessage, ApiConnectorLoginQuery, ApiPublicationPublishBody, ClientSideFile, ClientSideFileType, ConnectorData, ConnectorType, ConnectorUser, JobStatus, Initiator, PublicationData, PublicationJobData, PublicationSettings, WebsiteData, WebsiteFile, WebsiteId, WebsiteSettings } from '../../types'
-import { Editor } from 'grapesjs'
+import { Editor, Page } from 'grapesjs'
 import { PublicationUi } from './PublicationUi'
 import { getUser, logout, publicationStatus, publish } from '../api'
 import { API_CONNECTOR_LOGIN, API_CONNECTOR_PATH, API_PATH, SILEX_VERSION } from '../../constants'
@@ -25,6 +25,7 @@ import { ClientEvent } from '../events'
 import { resetRenderComponents, resetRenderCssRules, transformPermalink, transformFiles, transformPath, renderComponents, renderCssRules } from '../publication-transformers'
 import { hashString } from '../utils'
 import { displayedToStored, isExternalUrl } from '../assetUrl'
+import { enable11ty } from './cms/publication'
 
 /**
  * @fileoverview Publication manager for Silex
@@ -305,21 +306,23 @@ export class PublicationManager {
       // Get the data to publish, clone the objects because plugins can change it
       const projectData = { ...this.editor.getProjectData() as WebsiteData }
       const siteSettings = { ...this.editor.getModel().get('settings') as WebsiteSettings }
-      const pages = (projectData.pages as any[]) || []
-      const hasIndex = pages.some(page => {
-      const name = page?.name || ''
-      return name.toLowerCase() === 'index'
-       })
-       console.log(hasIndex);
-      if (!hasIndex) {
-        this.editor.runCommand('notifications:add', {
-          id: 'publish-missing-index-warning',
-          type: 'warning',
-          group: 'publication',
-          message:
-            'No page named "index" found. The first page will be used as homepage. Rename a page to "index" to control homepage.',
+      const pages = (projectData.pages ?? []) as  Page[]
+      if (!enable11ty()) {
+        const hasIndex = pages.some(page => {
+          const name = page.get('name') || ''
+          return getPageSlug(name) === 'index'
         })
-      }      
+
+        if (!hasIndex) {
+          this.editor.runCommand('notifications:add', {
+            id: 'publish-missing-index-warning',
+            type: 'warning',
+            group: 'publication',
+            message:
+              `Page "${pages[0]?.get('name')}": Will be used as homepage because no page is named "index". The homepage is the page served at the root URL of your site.`
+          })
+        }
+      }     
       
       // Check for missing SEO tags and warn user
       this.checkSeoTags(siteSettings)
@@ -544,6 +547,8 @@ export class PublicationManager {
   async *getHtmlFilesYield(siteSettings: WebsiteSettings, preventDefault): AsyncGenerator<WebsiteFile | undefined> {
     const pages = this.editor.Pages.getAll()
     const hasIndex = pages.some(p => getPageSlug(p.get('name')) === 'index')
+    const firstPageId = pages[0]?.getId()
+    const hasDataSource = enable11ty()
     for (const page of this.editor.Pages.getAll()) {
       // Clone the settings because plugins can change them
       const clonedSiteSettings = { ...siteSettings }
@@ -562,11 +567,9 @@ export class PublicationManager {
       yield undefined // Yield control to avoid blocking the main thread
 
       // Transform the file paths
-      let slug = getPageSlug(page.get('name'));
+      let slug = getPageSlug(page.get('name'))
       // if no index page exist make the first page as home page
-      const firstPageId = pages[0]?.getId()
-
-      if (!hasIndex && page.getId() === firstPageId) {
+      if (!hasDataSource && !hasIndex && page.getId() === firstPageId) {
         slug = 'index'
       }
       const cssInitialPath = `/css/${slug}-${await hashString(cssContent)}.css`

--- a/src/ts/client/grapesjs/PublicationManager.ts
+++ b/src/ts/client/grapesjs/PublicationManager.ts
@@ -17,7 +17,7 @@
 
 import { getPageSlug } from '../../page'
 import { ApiConnectorLoggedInPostMessage, ApiConnectorLoginQuery, ApiPublicationPublishBody, ClientSideFile, ClientSideFileType, ConnectorData, ConnectorType, ConnectorUser, JobStatus, Initiator, PublicationData, PublicationJobData, PublicationSettings, WebsiteData, WebsiteFile, WebsiteId, WebsiteSettings } from '../../types'
-import { Editor, Page } from 'grapesjs'
+import { Editor} from 'grapesjs'
 import { PublicationUi } from './PublicationUi'
 import { getUser, logout, publicationStatus, publish } from '../api'
 import { API_CONNECTOR_LOGIN, API_CONNECTOR_PATH, API_PATH, SILEX_VERSION } from '../../constants'
@@ -306,22 +306,16 @@ export class PublicationManager {
       // Get the data to publish, clone the objects because plugins can change it
       const projectData = { ...this.editor.getProjectData() as WebsiteData }
       const siteSettings = { ...this.editor.getModel().get('settings') as WebsiteSettings }
-      const pages = this.editor.Pages.getAll()
-      if (!enable11ty()) {
-        const hasIndex = pages.some(page => {
-          const name = page.get('name') || ''
-          return getPageSlug(name) === 'index'
-        })
+      const { pages, shouldPromoteFirstPage } = this.getHomepagePromotionInfo()
 
-        if (!hasIndex) {
-          this.editor.runCommand('notifications:add', {
-            id: 'publish-missing-index-warning',
-            type: 'warning',
-            group: 'publication',
-            message:
-              `Page "${pages[0]?.get('name')}": Will be used as homepage because no page is named "index". The homepage is the page served at the root URL of your site.`
-          })
-        }
+      if (shouldPromoteFirstPage) {
+        this.editor.runCommand('notifications:add', {
+          id: 'publish-missing-index-warning',
+          type: 'warning',
+          group: 'publication',
+          message:
+            `Page "${pages[0]?.get('name')}": Will be used as homepage because no page is named "index". The homepage is the page served at the root URL of your site.`
+        })
       }     
       
       // Check for missing SEO tags and warn user
@@ -376,6 +370,24 @@ export class PublicationManager {
       this.editor.trigger(ClientEvent.PUBLISH_ERROR, { success: false, message: e.message })
       this.editor.trigger(ClientEvent.PUBLISH_END, { success: false, message: e.message })
       return
+    }
+  }
+
+  /**
+   * Helper function to determine if the first page should be promoted to the homepage.
+   * @returns Information about homepage promotion, including whether the first page
+   * should be promoted, the first page ID, and the list of pages.
+   */
+  private getHomepagePromotionInfo() {
+    const pages = this.editor.Pages.getAll()
+    const hasIndex = pages.some(
+      page => getPageSlug(page.get('name')) === 'index'
+    )
+
+    return {
+      pages,
+      firstPageId: pages[0]?.getId(),
+      shouldPromoteFirstPage: !enable11ty() && !hasIndex, 
     }
   }
 
@@ -545,10 +557,11 @@ export class PublicationManager {
   }
 
   async *getHtmlFilesYield(siteSettings: WebsiteSettings, preventDefault): AsyncGenerator<WebsiteFile | undefined> {
-    const pages = this.editor.Pages.getAll()
-    const hasIndex = pages.some(p => getPageSlug(p.get('name')) === 'index')
-    const firstPageId = pages[0]?.getId()
-    const hasDataSource = enable11ty()
+    const {
+      pages,
+      firstPageId,
+      shouldPromoteFirstPage
+    } = this.getHomepagePromotionInfo()
     for (const page of this.editor.Pages.getAll()) {
       // Clone the settings because plugins can change them
       const clonedSiteSettings = { ...siteSettings }
@@ -567,10 +580,19 @@ export class PublicationManager {
       yield undefined // Yield control to avoid blocking the main thread
 
       // Transform the file paths
-      let slug = getPageSlug(page.get('name'))
+      const originalSlug = getPageSlug(page.get('name'))
+      let slug = originalSlug
       // if no index page exist make the first page as home page
-      if (!hasDataSource && !hasIndex && page.getId() === firstPageId) {
+      const promotedToIndex = shouldPromoteFirstPage && page.getId() === firstPageId
+      if (promotedToIndex) {
         slug = 'index'
+      }
+      let finalHtml = htmlContent
+      if (promotedToIndex) {
+        finalHtml = finalHtml.replaceAll(
+          `href="./${originalSlug}.html"`,
+          'href="./"'
+        )
       }
       const cssInitialPath = `/css/${slug}-${await hashString(cssContent)}.css`
       const htmlInitialPath = `/${slug}.html`
@@ -614,7 +636,7 @@ ${['description', 'og:title', 'og:description', 'og:image']
     .map((prop) => `<meta name="${prop}" property="${prop}" content="${getSetting(prop)}"/>`)
     .join('\n')}
 </head>
-${htmlContent}
+${finalHtml}
 </html>`,
         css: cssContent,
         cssPath,

--- a/src/ts/client/grapesjs/PublicationManager.ts
+++ b/src/ts/client/grapesjs/PublicationManager.ts
@@ -306,7 +306,7 @@ export class PublicationManager {
       // Get the data to publish, clone the objects because plugins can change it
       const projectData = { ...this.editor.getProjectData() as WebsiteData }
       const siteSettings = { ...this.editor.getModel().get('settings') as WebsiteSettings }
-      const pages = (projectData.pages ?? []) as  Page[]
+      const pages = this.editor.Pages.getAll()
       if (!enable11ty()) {
         const hasIndex = pages.some(page => {
           const name = page.get('name') || ''

--- a/src/ts/client/grapesjs/cms/publication.ts
+++ b/src/ts/client/grapesjs/cms/publication.ts
@@ -69,7 +69,7 @@ export default function (editor: Editor, options: EleventyPluginOptions) {
 /**
  * Check if the 11ty publication is enabled
  */
-function enable11ty(): boolean {
+export function enable11ty(): boolean {
   return getAllDataSources()
     .filter(ds => ds.id !== EleventyDataSourceId)
     .length > 0


### PR DESCRIPTION
## Description

This PR addresses the issue reported in silexlabs/Silex#1689.

Currently, publishing fails and throws an error when there is no first page defined in the website.This PR improves the behavior by:

- Detecting when no first page is configured
- Automatically using the current first available page as the `index`
- Displaying a notification to inform the user about the fallback behavior

This provides a smoother publishing experience and prevents the publication process from failing unexpectedly.

### Changes made

- Added validation for missing first page during publication
- Added fallback logic to use the first available page as the index page
- Added user notification message during publishing
- Prevented publication failure caused by missing first page configuration


## Before


https://github.com/user-attachments/assets/d559ce28-2f6c-48bd-ab4d-e6f9f1bc041e



## After


https://github.com/user-attachments/assets/9e364e9a-4f8b-4b24-a373-a8d07c684494



## Related Issue

Related to silexlabs/Silex#1689