### PR TITLE
fix: clean up downloaded zip files

### DIFF
--- a/src/ts/plugins/server/DownloadConnector.test.ts
+++ b/src/ts/plugins/server/DownloadConnector.test.ts
@@ -1,0 +1,70 @@
+import { expect, jest, beforeEach, it, describe } from '@jest/globals'
+import { ServerEvent } from '../../server/events'
+
+const unlink = jest.fn((_path, cb: (err?: Error) => void) => cb())
+
+jest.unstable_mockModule('fs', () => ({
+  createWriteStream: jest.fn(),
+  unlink,
+}))
+
+jest.unstable_mockModule('os', () => ({
+  tmpdir: () => '/tmp',
+}))
+
+const DownloadConnector = (await import('./DownloadConnector')).default
+
+function createRouteHandler() {
+  const app = {
+    get: jest.fn(),
+  }
+  const config = {
+    on: jest.fn((_event, callback: (payload: {app: typeof app}) => void) => callback({app})),
+  }
+
+  new DownloadConnector(config as never)
+
+  expect(config.on).toHaveBeenCalledWith(ServerEvent.STARTUP_END, expect.any(Function))
+  expect(app.get).toHaveBeenCalledWith('/download/:tmpZipFile', expect.any(Function))
+
+  return app.get.mock.calls[0][1] as (req, res) => Promise<void>
+}
+
+beforeEach(() => {
+  unlink.mockClear()
+})
+
+describe('DownloadConnector download route', () => {
+  it('deletes the temporary zip after a successful download', async () => {
+    const handler = createRouteHandler()
+    const sendFile = jest.fn((_path, _options, callback: (err?: Error) => void) => callback())
+    const res = {
+      sendFile,
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }
+
+    await handler({params: {tmpZipFile: 'website-123.zip'}}, res)
+
+    expect(sendFile).toHaveBeenCalledWith('/tmp/website-123.zip', {}, expect.any(Function))
+    expect(unlink).toHaveBeenCalledWith('/tmp/website-123.zip', expect.any(Function))
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe temporary zip names', async () => {
+    const handler = createRouteHandler()
+    const res = {
+      sendFile: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }
+
+    await handler({params: {tmpZipFile: '../secret.zip'}}, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.send).toHaveBeenCalledWith('Invalid download file')
+    expect(res.sendFile).not.toHaveBeenCalled()
+    expect(unlink).not.toHaveBeenCalled()
+  })
+})

--- a/src/ts/plugins/server/DownloadConnector.ts
+++ b/src/ts/plugins/server/DownloadConnector.ts
@@ -1,8 +1,9 @@
-import { createWriteStream } from 'fs'
+import { createWriteStream, unlink } from 'fs'
 import archiver from 'archiver'
 import { ConnectorOptions, ConnectorType, ConnectorUser, JobData, JobStatus, PublicationJobData, WebsiteId } from '../../types'
 import { ConnectorFile, ConnectorSession, HostingConnector } from '../../server/connectors/connectors'
 import { tmpdir } from 'os'
+import { join } from 'path'
 import { JobManager } from '../../server/jobs'
 import { ServerConfig } from '../../server/config'
 import { ServerEvent } from '../../server/events'
@@ -29,16 +30,25 @@ export default class implements HostingConnector<DownloadConnectorSession> {
     // Add a route to serve the zip file
     config.on(ServerEvent.STARTUP_END, ({app}) => {
       app.get('/download/:tmpZipFile', async (req: Request, res: Response) => {
-        const path = `${tmpdir()}/${req.params.tmpZipFile}`
+        const {tmpZipFile} = req.params
+        if (tmpZipFile.includes('/') || tmpZipFile.includes('\\') || tmpZipFile.includes('..')) {
+          res.status(400).send('Invalid download file')
+          return
+        }
+        const path = join(tmpdir(), tmpZipFile)
         res.sendFile(path, {}, (err) => {
           if (err) {
             console.error('[DownloadConnector] Error while sending file', err)
-            res.status(500).send(`
+            if (!res.headersSent) res.status(500).send(`
               <h1>Error</h1>
               <p>There was an error while getting the zip file of your website</p>
               <p>${err.message}</p>
             `)
+            return
           }
+          unlink(path, (unlinkErr) => {
+            if (unlinkErr) console.error('[DownloadConnector] Error while deleting temporary zip file', unlinkErr)
+          })
         })
       })
     })


### PR DESCRIPTION
Fixes silexlabs/Silex#1725.

This updates the Download connector route so generated zip files are removed from the OS temp directory after a successful `res.sendFile()` transfer. Failed downloads keep the zip in place so the user can retry.

It also rejects unsafe `:tmpZipFile` parameters containing path separators or `..`, so the download route cannot be used to read files outside the temp directory.

Verification:

- `yarn test src/ts/plugins/server/DownloadConnector.test.ts --runInBand`
- `yarn lint --quiet src/ts/plugins/server/DownloadConnector.ts src/ts/plugins/server/DownloadConnector.test.ts`
- `yarn build:plugins:server`
- `git diff --check`

Note: the local pre-commit hook reran `yarn install`, but that hook failed after the verified checks above because the sandboxed environment could not resolve `registry.yarnpkg.com`.
